### PR TITLE
Adapt icon path removal from core

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target/
+.idea

--- a/src/main/resources/org/ow2/clif/jenkins/ImportZipAction/index.jelly
+++ b/src/main/resources/org/ow2/clif/jenkins/ImportZipAction/index.jelly
@@ -4,7 +4,7 @@
 	<l:layout title="clif" secured="true">
 		<l:side-panel>
 			<l:tasks>
-				<l:task icon="images/24x24/up.gif" href="${rootURL}/" title="${%Back to Dashboard}"/>
+				<l:task icon="icon-up icon-md" href="${rootURL}/" title="${%Back to Dashboard}"/>
 			</l:tasks>
 		</l:side-panel>
 		<l:main-panel>

--- a/src/main/resources/org/ow2/clif/jenkins/PreviewZipAction/index.jelly
+++ b/src/main/resources/org/ow2/clif/jenkins/PreviewZipAction/index.jelly
@@ -4,7 +4,7 @@
 	<l:layout title="clif" secured="true">
 		<l:side-panel>
 			<l:tasks>
-				<l:task icon="images/24x24/up.gif" href="${rootURL}/" title="${%Back to Dashboard}"/>
+				<l:task icon="icon-up icon-md" href="${rootURL}/" title="${%Back to Dashboard}"/>
 			</l:tasks>
 		</l:side-panel>
 		<l:main-panel>
@@ -24,7 +24,7 @@
 					<f:block>
 						<div style="height:20px"/>
 						<div class="section-header">
-							<img src='${imagesURL}/24x24/refresh.png' height='16' width='16'/>
+							<l:icon class='icon-refresh icon-sm'/>
 							${%title.upgrade}
 						</div>
 
@@ -45,7 +45,7 @@
 					<f:block>
 						<div style="height:20px"/>
 						<div class="section-header">
-							<img src='${imagesURL}/24x24/new-package.png' height='16' width='16'/>
+							<l:icon class='icon-new-package icon-sm'/>
 							${%title.install}
 						</div>
 					</f:block>
@@ -61,7 +61,7 @@
 					<f:block>
 						<div style="height:20px"/>
 						<div class="section-header">
-							<img src='${imagesURL}/24x24/edit-delete.png' height='16' width='16'/>
+							<l:icon class='icon-edit-delete icon-sm'/>
 							${%title.uninstall}
 						</div>
 					</f:block>


### PR DESCRIPTION
The change proposed prepares the plugin for the icon path removal from core in the upcoming LTS line. This change affects plugins not using the icon API or relying on paths. Plugins using the API properly in the first place are unaffected by this change.

Could you trigger a release after merging this PR please, giving people a chance to update the plugin before updating to the next LTS version @dillense 
Thanks in advance!