### PR TITLE
Discarded implicit conversion from Double to double

### DIFF
--- a/src/main/java/org/ow2/clif/jenkins/ClifPublisher.java
+++ b/src/main/java/org/ow2/clif/jenkins/ClifPublisher.java
@@ -367,7 +367,7 @@ public class ClifPublisher
 	protected static double getDouble(String value) {
 		if (StringUtils.isNotBlank(value)) {
 			try {
-				return Double.valueOf(value);
+				return Double.parseDouble(value);
 			}
 			catch (NumberFormatException e) {
 				return -1;


### PR DESCRIPTION
Fix to comply with spotBug requirements:
> Boxing/unboxing to parse a primitive
> A boxed primitive is created from a String, just to extract the unboxed primitive value. It is more efficient to just call the static parseXXX method.
> Bug kind and pattern: Bx - DM_BOXED_PRIMITIVE_FOR_PARSING