### PR TITLE
Refresh plugin

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -2,6 +2,6 @@
   <extension>
     <groupId>io.jenkins.tools.incrementals</groupId>
     <artifactId>git-changelist-maven-extension</artifactId>
-    <version>1.3</version>
+    <version>1.4</version>
   </extension>
 </extensions>

--- a/pom.xml
+++ b/pom.xml
@@ -1,9 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.jenkins-ci.plugins</groupId>
 		<artifactId>plugin</artifactId>
-		<version>4.42</version>
+		<version>4.48</version>
 	</parent>
 	<artifactId>clif-performance-testing</artifactId>
 	<version>${changelist}</version>
@@ -16,11 +17,12 @@
 	Note: at least one CLIF server runtime to be installed along with this plug-in. 
 	</description>
 
-	<url>https://github.com/jenkinsci/clif-performance-testing-plugin</url>
+	<url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
 
 	<properties>
 		<changelist>999999-SNAPSHOT</changelist>
-		<jenkins.version>2.277.4</jenkins.version>
+		<jenkins.version>2.332.1</jenkins.version>
+		<gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
 	</properties>
 
 	<repositories>
@@ -54,6 +56,10 @@
 			<artifactId>clif-api</artifactId>
 			<version>3.0.1</version>
 		 <exclusions>
+		  <exclusion>
+		   <groupId>log4j</groupId>
+		   <artifactId>log4j</artifactId>
+		  </exclusion>
 		  <exclusion>
 		   <groupId>org.mortbay.jetty</groupId>
 		   <artifactId>jetty</artifactId>
@@ -91,25 +97,8 @@
 		</dependency>
 		<dependency>
 			<groupId>org.mockito</groupId>
-			<artifactId>mockito-all</artifactId>
-			<version>1.9.0</version>
+			<artifactId>mockito-core</artifactId>
 			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.easytesting</groupId>
-			<artifactId>fest-assert</artifactId>
-			<version>1.3</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-    		<groupId>org.jenkins-ci</groupId>
-    		<artifactId>symbol-annotation</artifactId>
-		    <version>1.12</version> <!-- TODO pick up from core BOM -->
-		</dependency>
-		<dependency>
-			<groupId>com.google.code.findbugs</groupId>
-			<artifactId>annotations</artifactId>
-			<version>3.0.1</version>
 		</dependency>
 	</dependencies>
 	<build>
@@ -252,9 +241,9 @@
 	</mailingLists>
 
 	<scm>
-		<connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
-		<developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
-		<url>https://github.com/jenkinsci/clif-performance-testing-plugin</url>
+		<connection>scm:git:https://github.com/${gitHubRepo}.git</connection>
+		<developerConnection>scm:git:git@github.com:${gitHubRepo}.git</developerConnection>
+		<url>https://github.com/${gitHubRepo}</url>
 		<tag>${scmTag}</tag>
 	</scm>
 

--- a/src/test/java/jenkins/model/FakeTest.java
+++ b/src/test/java/jenkins/model/FakeTest.java
@@ -20,25 +20,28 @@
  */
 package jenkins.model;
 
-import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
 import hudson.model.FreeStyleProject;
 import hudson.model.Item;
 import hudson.model.ItemGroup;
-import static org.fest.assertions.Assertions.assertThat;
+import org.junit.Test;
 
 public class FakeTest {
 
 	@Test
 	public void canFakeAndResetGlobals() {
-		assertThat(Jenkins.getInstance()).isNull();
+		assertNull(Jenkins.getInstance());
 		Jenkins jenkins = Fake.install();
 
-		assertThat(jenkins).isNotNull();
-		assertThat(Jenkins.getInstance()).isEqualTo(jenkins);
+		assertNotNull(jenkins);
+		assertEquals(jenkins, Jenkins.getInstance());
 
 		Jenkins j = Fake.uninstall();
-		assertThat(j).isNull();
-		assertThat(Jenkins.getInstance()).isNull();
+		assertNull(j);
+		assertNull(Jenkins.getInstance());
 	}
 
 
@@ -49,7 +52,7 @@ public class FakeTest {
 					(ItemGroup<? extends Item>) jenkins.getItemGroup(),
 					"bar"
 			);
-			assertThat(project.getParent()).isEqualTo(jenkins);
+			assertEquals(jenkins, project.getParent());
 		}
 		finally {
 			Fake.uninstall();

--- a/src/test/java/org/ow2/clif/jenkins/ClifInstallationTest.java
+++ b/src/test/java/org/ow2/clif/jenkins/ClifInstallationTest.java
@@ -30,7 +30,6 @@ import hudson.Util;
 import hudson.util.FormValidation;
 import static hudson.util.FormValidation.Kind.ERROR;
 import static hudson.util.FormValidation.Kind.OK;
-import static org.fest.assertions.Assertions.assertThat;
 
 
 /**
@@ -156,7 +155,7 @@ public class ClifInstallationTest extends HudsonTestCase
 		final String expectedMessage)
 	{
 		final FormValidation res = desc.doCheckInstallation(home, schedulerURL, schedulerCredentialsFile, null, null);
-		assertThat(res.getMessage()).isEqualTo(Util.escape(expectedMessage));
-		assertThat(res.kind).isEqualTo(expectedKind);
+		assertEquals(Util.escape(expectedMessage), res.getMessage());
+		assertEquals(expectedKind, res.kind);
 	}
 }

--- a/src/test/java/org/ow2/clif/jenkins/ClifPublisherTest.java
+++ b/src/test/java/org/ow2/clif/jenkins/ClifPublisherTest.java
@@ -21,19 +21,19 @@
 package org.ow2.clif.jenkins;
 
 import org.junit.Test;
-import static org.fest.assertions.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
 
 public class ClifPublisherTest {
 
 	@Test
 	public void unboundConstructor() throws Exception {
 		ClifPublisher publisher = new ClifPublisher("bar");
-		assertThat(publisher.getChartHeight()).isEqualTo(600);
-		assertThat(publisher.getChartWidth()).isEqualTo(1200);
-		assertThat(publisher.getDistributionSliceSize()).isEqualTo(50);
+		assertEquals(600, publisher.getChartHeight());
+		assertEquals(1200, publisher.getChartWidth());
+		assertEquals(50, publisher.getDistributionSliceSize());
 
 		ClifDataCleanup cleanup = publisher.getDataCleanupConfig();
-		assertThat(cleanup.getKeepFactor()).isEqualTo(2);
-		assertThat(cleanup.getKeepPercentage()).isEqualTo(95);
+		assertEquals(2.0, cleanup.getKeepFactor(), 0.1);
+		assertEquals(95.0, cleanup.getKeepPercentage(), 0.1);
 	}
 }

--- a/src/test/java/org/ow2/clif/jenkins/PreviewZipActionTest.java
+++ b/src/test/java/org/ow2/clif/jenkins/PreviewZipActionTest.java
@@ -20,6 +20,8 @@
  */
 package org.ow2.clif.jenkins;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import org.junit.After;
 import org.junit.Before;
@@ -33,9 +35,13 @@ import hudson.model.FreeStyleProject;
 import hudson.model.Item;
 import jenkins.model.Fake;
 import jenkins.model.Jenkins;
-import static com.google.common.collect.Lists.newArrayList;
-import static org.fest.assertions.Assertions.assertThat;
-import static org.mockito.Mockito.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class PreviewZipActionTest {
 	private Jenkins jenkins;
@@ -64,7 +70,7 @@ public class PreviewZipActionTest {
 	}
 
 	List<Item> jobs(String... names) {
-		List<Item> jobs = newArrayList();
+		List<Item> jobs = new ArrayList<>();
 		for (String name : names) {
 			FreeStyleProject job = job(name);
 			jobs.add(job);
@@ -83,13 +89,13 @@ public class PreviewZipActionTest {
 
 	@Test
 	public void doesNotListNestedTestPlanInZip() throws Exception {
-		assertThat(preview.pattern).isEqualTo("([^/]*)/([^/]*)\\.ctp");
+		assertThat(preview.pattern, equalTo("([^/]*)/([^/]*)\\.ctp"));
 	}
 
 	@Test
 	public void jobNameIsDasherizedFileNameWithoutExtension() throws Exception {
 		FreeStyleProject project = preview.create("red/tomato.erl");
-		assertThat(project.getName()).isEqualTo("red-tomato");
+		assertThat(project.getName(), equalTo("red-tomato"));
 	}
 
 	@Test
@@ -115,22 +121,22 @@ public class PreviewZipActionTest {
 		preview.process(response);
 
 		verify(response).sendRedirect2("previews/123");
-		assertThat(parent.getPreviews(preview.id())).isEqualTo(preview);
+		assertThat(parent.getPreviews(preview.id()), equalTo(preview));
 	}
 
 	@Test
 	public void diffingZipAgainstJobs() throws Exception {
 		jobs("examples-dummy", "examples-synchro", "rebar");
 		when(zip.entries(anyString())).thenReturn(
-				newArrayList("examples/dummy.ctp", "examples/ftp.ctp")
+				Arrays.asList("examples/dummy.ctp", "examples/ftp.ctp")
 		);
 		when(zip.basedir()).thenReturn("examples");
 
 		preview.diff();
 
-		assertThat(preview.installs).containsOnly("examples/ftp.ctp");
-		assertThat(preview.uninstalls).containsOnly("examples/synchro.ctp");
-		assertThat(preview.upgrades).containsOnly("examples/dummy.ctp");
+		assertThat(preview.installs, contains("examples/ftp.ctp"));
+		assertThat(preview.uninstalls, contains("examples/synchro.ctp"));
+		assertThat(preview.upgrades, contains("examples/dummy.ctp"));
 	}
 
 }

--- a/src/test/java/org/ow2/clif/jenkins/jobs/ConfigurerTest.java
+++ b/src/test/java/org/ow2/clif/jenkins/jobs/ConfigurerTest.java
@@ -21,83 +21,71 @@
  */
 package org.ow2.clif.jenkins.jobs;
 
+import hudson.model.FreeStyleProject;
 import java.io.File;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
 import org.ow2.clif.jenkins.ClifBuilder;
 import org.ow2.clif.jenkins.ClifPublisher;
-import hudson.model.Descriptor;
-import hudson.model.FreeStyleProject;
-import hudson.tasks.Builder;
-import hudson.tasks.Publisher;
-import hudson.util.DescribableList;
-import static org.fest.assertions.Assertions.assertThat;
-import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.Assert.assertEquals;
 
 public class ConfigurerTest {
 
-	private Installations installations;
+	@Rule public JenkinsRule j = new JenkinsRule();
+
 	private Configurer configurer;
-	private FreeStyleProject project;
 	private File dir;
 
 	@Before
-	@SuppressWarnings("unchecked")
 	public void setUp() {
-		installations = mock(Installations.class);
 		configurer = new Configurer();
-		configurer.installations = installations;
-
-		project = mock(FreeStyleProject.class);
-		DescribableList<Builder, Descriptor<Builder>> builders =
-				mock(DescribableList.class);
-		when(project.getBuildersList()).thenReturn(builders);
-
-		DescribableList<Publisher, Descriptor<Publisher>> publishers =
-				mock(DescribableList.class);
-		when(project.getPublishersList()).thenReturn(publishers);
-
 		dir = new File("target/workspaces");
 	}
 
 	@Test
-	public void configureAddsOneClifBuilderToProjectBuilderList()
-			throws Exception {
+	public void configureAddsOneClifBuilderToProjectBuilderList() throws Exception {
+		FreeStyleProject project = j.createFreeStyleProject();
 		configurer.configure(project, dir, "nowhere/noTestPlan.ctp");
-		verify(project.getBuildersList()).add(any(ClifBuilder.class));
+		assertThat(project.getBuildersList(), hasSize(1));
+		assertThat(project.getBuildersList().get(0), instanceOf(ClifBuilder.class));
 	}
 
 	@Test
 	public void configurePublisher() throws Exception {
+		FreeStyleProject project = j.createFreeStyleProject();
 		configurer.configure(project, dir, "nowhere/noTestPlan.ctp");
-		verify(project.getPublishersList()).add(any(ClifPublisher.class));
+		assertThat(project.getBuildersList(), hasSize(1));
+		assertThat(project.getBuildersList().get(0), instanceOf(ClifBuilder.class));
 	}
 
 	@Test
 	public void configurePrivateWorkspace() throws Exception {
+		FreeStyleProject project = j.createFreeStyleProject();
 		configurer.configure(project, dir, "examples/http.ctp");
-		verify(project).setCustomWorkspace(new File("target/workspaces/examples").getPath());
-
+		assertEquals("target/workspaces/examples", project.getCustomWorkspace());
 	}
 
 	@Test
-	public void newClifBuilderHasTestPlan() throws Exception {
+	public void newClifBuilderHasTestPlan() {
 		ClifBuilder builder = configurer.newClifBuilder("http.ctp");
-		assertThat(builder.getTestPlanFile()).isEqualTo("http.ctp");
+		assertEquals("http.ctp", builder.getTestPlanFile());
 	}
 
 	@Test
-	public void newClifBuilderHasReportDir() throws Exception {
+	public void newClifBuilderHasReportDir() {
 		ClifBuilder builder = configurer.newClifBuilder("http.ctp");
-		assertThat(builder.getReportDir()).isEqualTo("report");
+		assertEquals("report", builder.getReportDir());
 	}
 
 	@Test
-	public void newClifPublisherHasReportDirectory() throws Exception {
+	public void newClifPublisherHasReportDirectory() {
 		ClifPublisher publisher = configurer.newClifPublisher();
-		assertThat(publisher.getClifReportDirectory())
-				.isEqualTo("report");
+		assertEquals("report", publisher.getClifReportDirectory());
 	}
 
 }

--- a/src/test/java/org/ow2/clif/jenkins/jobs/ConfigurerTest.java
+++ b/src/test/java/org/ow2/clif/jenkins/jobs/ConfigurerTest.java
@@ -67,7 +67,7 @@ public class ConfigurerTest {
 	public void configurePrivateWorkspace() throws Exception {
 		FreeStyleProject project = j.createFreeStyleProject();
 		configurer.configure(project, dir, "examples/http.ctp");
-		assertEquals("target/workspaces/examples", project.getCustomWorkspace());
+		assertEquals("target" + File.separator + "workspaces" + File.separator + "examples", project.getCustomWorkspace());
 	}
 
 	@Test

--- a/src/test/java/org/ow2/clif/jenkins/jobs/FileSystemTest.java
+++ b/src/test/java/org/ow2/clif/jenkins/jobs/FileSystemTest.java
@@ -26,7 +26,8 @@ import org.apache.commons.io.FileUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import static org.fest.assertions.Assertions.assertThat;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class FileSystemTest {
 	private String path;
@@ -67,8 +68,8 @@ public class FileSystemTest {
 
 		fs.rm_rf("**/synchro*");
 
-		assertThat(f).doesNotExist();
-		assertThat(monster).doesNotExist();
-		assertThat(elvis).exists();
+		assertFalse(f.exists());
+		assertFalse(monster.exists());
+		assertTrue(elvis.exists());
 	}
 }

--- a/src/test/java/org/ow2/clif/jenkins/jobs/ParameterParserTest.java
+++ b/src/test/java/org/ow2/clif/jenkins/jobs/ParameterParserTest.java
@@ -22,7 +22,9 @@ package org.ow2.clif.jenkins.jobs;
 
 import org.junit.Before;
 import org.junit.Test;
-import static org.fest.assertions.Assertions.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.anEmptyMap;
+import static org.hamcrest.Matchers.equalTo;
 
 public class ParameterParserTest {
 	private ParameterParser parser;
@@ -37,14 +39,11 @@ public class ParameterParserTest {
 		// convention like this one for parameter name
 		// http://guides.rubyonrails.org/action_controller_overview.html#hash-and-array-parameters
 		assertThat(
-				parser.parse("examples/synchro.ctp[uninstall]").get("examples/synchro.ctp")
-		).isEqualTo("uninstall");
+				parser.parse("examples/synchro.ctp[uninstall]").get("examples/synchro.ctp"), equalTo("uninstall"));
 	}
 
 	@Test
 	public void isSilentOtherwise() throws Exception {
-		assertThat(
-				parser.parse("json")
-		).isEmpty();
+		assertThat(parser.parse("json"), anEmptyMap());
 	}
 }

--- a/src/test/java/org/ow2/clif/jenkins/jobs/ZipExtractTest.java
+++ b/src/test/java/org/ow2/clif/jenkins/jobs/ZipExtractTest.java
@@ -26,7 +26,7 @@ import org.apache.commons.io.FileUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import static org.fest.assertions.Assertions.assertThat;
+import static org.junit.Assert.assertTrue;
 
 public class ZipExtractTest {
 	private Zip zip;
@@ -49,7 +49,7 @@ public class ZipExtractTest {
 	public void extractsToDirectoryDeflatesAllZip() throws Exception {
 		zip = new Zip("src/test/resources/zips/nested.zip");
 		zip.extractTo(path);
-		assertThat(new File(workspaces + "/samples")).isDirectory();
-		assertThat(new File(workspaces + "/samples/post.ctp")).isFile();
+		assertTrue(new File(workspaces + "/samples").isDirectory());
+		assertTrue(new File(workspaces + "/samples/post.ctp").isFile());
 	}
 }

--- a/src/test/java/org/ow2/clif/jenkins/parser/clif/ClifParserTest.java
+++ b/src/test/java/org/ow2/clif/jenkins/parser/clif/ClifParserTest.java
@@ -26,7 +26,13 @@ import org.junit.Test;
 import org.ow2.clif.jenkins.chart.ChartConfiguration;
 import org.ow2.clif.jenkins.model.ClifReport;
 import org.ow2.clif.jenkins.model.TestPlan;
-import static org.fest.assertions.Assertions.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.anyOf;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertNotNull;
 
 /**
@@ -55,14 +61,15 @@ public class ClifParserTest {
 		ClifReport report = parser.parse(System.out);
 
 		assertNotNull(report);
-		assertThat(report.getTestplans()).isNotEmpty().containsExactly(new TestPlan("random", new Date()));
+		assertThat(report.getTestplans(), not(empty()));
+		assertThat(report.getTestplans(), contains(new TestPlan("random", new Date())));
 
 		TestPlan testPlanRead = report.getTestplan("random");
-		assertThat(testPlanRead.getAggregatedMeasures()).hasSize(1);
-		assertThat(testPlanRead.getAlarms()).isNullOrEmpty();
-		assertThat(testPlanRead.getInjectors()).hasSize(1);
-		assertThat(testPlanRead.getProbes()).isNullOrEmpty();
-		assertThat(testPlanRead.getServers()).hasSize(1);
+		assertThat(testPlanRead.getAggregatedMeasures(), hasSize(1));
+		assertThat(testPlanRead.getAlarms(), anyOf(nullValue(),empty()));
+		assertThat(testPlanRead.getInjectors(), hasSize(1));
+		assertThat(testPlanRead.getProbes(), anyOf(nullValue(),empty()));
+		assertThat(testPlanRead.getServers(), hasSize(1));
 
 		start += System.currentTimeMillis();
 		System.out.println(start);


### PR DESCRIPTION
Upgrades the plugin to the latest build toolchain, including updating the tests to the latest versions of JUnit, Hamcrest, and Mockito, which are the standard supported libraries for Jenkins plugins.

CC @dillense