### PR TITLE
Bundle ANTLR 2, as core no longer provides it

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,4 @@
-buildPlugin()
+buildPlugin(useContainerAgent: true, configurations: [
+  [ platform: 'linux', jdk: '11' ],
+  [ platform: 'windows', jdk: '11' ],
+])

--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,10 @@
 		   <artifactId>log4j</artifactId>
 		  </exclusion>
 		  <exclusion>
+		   <groupId>org.bouncycastle</groupId>
+		   <artifactId>bcprov-jdk15</artifactId>
+		  </exclusion>
+		  <exclusion>
 		   <groupId>org.mortbay.jetty</groupId>
 		   <artifactId>jetty</artifactId>
 		  </exclusion>
@@ -94,6 +98,12 @@
 			<groupId>commons-math</groupId>
 			<artifactId>commons-math</artifactId>
 			<version>1.2</version>
+		</dependency>
+		<dependency>
+			<groupId>org.jenkins-ci.modules</groupId>
+			<artifactId>instance-identity</artifactId>
+			<version>116.vf8f487400980</version>
+			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.mockito</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
 	<properties>
 		<changelist>999999-SNAPSHOT</changelist>
-		<jenkins.version>2.332.1</jenkins.version>
+		<jenkins.version>2.376</jenkins.version>
 		<gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
 	</properties>
 


### PR DESCRIPTION
This plugin depends on `org.ow2.clif:clif-api:3.0.1`, which depends on `org.objectweb.proactive:proactive-programming-bundle:5.2.0-update-12`, which depends on `antlr:antlr:2.7.7`:

```
[INFO] +- org.ow2.clif:clif-api:jar:3.0.1:compile
[INFO] |  \- org.objectweb.proactive:proactive-programming-bundle:jar:5.2.0-update-12:compile
[INFO] |     |  +- antlr:antlr:jar:2.7.7:compile
```

ANTLR 2 used to be bundled with Jenkins core but is no longer bundled with Jenkins core as of Jenkins 2.376. This plugin does not bundle ANTLR 2 either.

There is a possibility that on upgrade to 2.376, linkage errors may occur when `clif-api` attempts to load ANTLR 2 classes via `proactive-programming-bundle`. This may or may not be a real issue depending on which code paths are being exercised in `proactive-programming-bundle`.

If it is a real issue, then this PR solves the problem by bumping the baseline to 2.376, resulting in `maven-hpi-plugin` bundling ANTLR 2 with this plugin:

```
[INFO] --- maven-hpi-plugin:3.34:hpi (default-hpi) @ clif-performance-testing ---
[INFO] Generating jenkinsci/clif-performance-testing-plugin/target/clif-performance-testing/META-INF/MANIFEST.MF
[INFO] Checking for attached .jar artifact ...
[INFO] Generating jar jenkinsci/clif-performance-testing-plugin/target/clif-performance-testing.jar
[INFO] Building jar: jenkinsci/clif-performance-testing-plugin/target/clif-performance-testing.jar
[INFO] Exploding webapp...
[INFO] Copy webapp webResources to jenkinsci/clif-performance-testing-plugin/target/clif-performance-testing
[INFO] Assembling webapp clif-performance-testing in jenkinsci/clif-performance-testing-plugin/target/clif-performance-testing
[WARNING] Bundling transitive dependency antlr-2.7.7.jar (via clif-api)
[…]
[INFO] Generating hpi jenkinsci/clif-performance-testing-plugin/target/clif-performance-testing.hpi
[INFO] Building jar: jenkinsci/clif-performance-testing-plugin/target/clif-performance-testing.hpi
```

If this is not a real issue due to the relevant code paths not being exercised, this PR can simply be closed.

CC @dillense