### PR TITLE
feature#JENKINS-74593: moved inline javascript to a script file

### DIFF
--- a/src/main/resources/org/ow2/clif/jenkins/ClifBuildAction/index.jelly
+++ b/src/main/resources/org/ow2/clif/jenkins/ClifBuildAction/index.jelly
@@ -106,10 +106,7 @@
 										<g:alarm testPlan="${testPlan}" level="FATAL"/>
 									</div>
 
-									<script type="text/javascript">
-										var tabView = new YAHOO.widget.TabView('alarms${testPlan.name}');
-										tabView.getTab(0).active = true;
-									</script>
+ 									<st:adjunct includes="yui-mapview-init"/>
 								</div>
 
 

--- a/src/main/webapp/yui-tabview-init.js
+++ b/src/main/webapp/yui-tabview-init.js
@@ -1,0 +1,4 @@
+(function() {
+    var tabView = new YAHOO.widget.TabView('alarms${testPlan.name}');
+    tabView.getTab(0).active = true;
+})()


### PR DESCRIPTION
see https://issues.jenkins.io/browse/JENKINS-74593
followed hints in https://www.jenkins.io/doc/developer/security/csp/#inline-javascript-blocks and referenced example:
moved inline javascript to a script file using adjunct element for alarms table initialization

### Testing done

Manually tested that the alarms table in test reports is still present when alarms have been generated, and works as before (no regression)

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira

